### PR TITLE
run.sh: Reduce dependency footprint

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,45 +1,14 @@
-#!/bin/bash
+#!/bin/sh
 set +e
 set -o noglob
-
-
-#
-# Set Colors
-#
-
-bold=$(tput bold)
-underline=$(tput sgr 0 1)
-reset=$(tput sgr0)
-
-red=$(tput setaf 1)
-green=$(tput setaf 76)
-white=$(tput setaf 7)
-tan=$(tput setaf 202)
-blue=$(tput setaf 25)
 
 #
 # Headers and Logging
 #
 
-underline() { printf "${underline}${bold}%s${reset}\n" "$@"
+error() { printf "✖ %s\n" "$@"
 }
-h1() { printf "\n${underline}${bold}${blue}%s${reset}\n" "$@"
-}
-h2() { printf "\n${underline}${bold}${white}%s${reset}\n" "$@"
-}
-debug() { printf "${white}%s${reset}\n" "$@"
-}
-info() { printf "${white}➜ %s${reset}\n" "$@"
-}
-success() { printf "${green}✔ %s${reset}\n" "$@"
-}
-error() { printf "${red}✖ %s${reset}\n" "$@"
-}
-warn() { printf "${tan}➜ %s${reset}\n" "$@"
-}
-bold() { printf "${bold}%s${reset}\n" "$@"
-}
-note() { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset}\n" "$@"
+warn() { printf "➜ %s\n" "$@"
 }
 
 type_exists() {
@@ -57,7 +26,14 @@ fi
 
 # Check pip is installed
 if ! type_exists 'pip'; then
-  curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | sudo python2.7
+  if type_exists 'curl'; then
+    curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | sudo python2.7
+  elif type_exists 'wget' && type_exists 'openssl'; then
+    wget -q -O - https://bootstrap.pypa.io/get-pip.py | sudo python2.7
+  else
+    error "Please install pip, curl, or wget with openssl"
+    exit 1
+  fi
 fi
 
 # Install python dependencies


### PR DESCRIPTION
When deploying a Docker container, it's common to choose a very minimal base image such as one based on alpine, and not only are many of the commands used in run.sh not installed by default in that image, some of them aren't available in the package manager.

This PR:
- removes a lot of functions and variables that are not used
- removes colors and styling from output (`tput` isn't always available, and Wercker's output doesn't show colors anyway)
- runs the script through `/bin/sh` instead of `/bin/bash`, which isn't always available
- allows `wget` to be used if `curl` isn't available (this is the case on alpine)

Now, if alpine is being used as the base box, adding this script step in the deploy pipeline will allow this step to run:

``` yaml
- script:
    name: install ecs deployment deps
    code: |
      apk update
      apk add python openssl sudo
```

Note: theoretically sudo could be removed as well, but since it's very small and available in alpine's package manager, I didn't feel it necessary.
