### PR TITLE
Use actual ECS task definition file, drop name req

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ This step register a new task definition for the service.
 
 The following configuration allows to setup this step :
 
-* `task-definition-name` (required): The name of the task definition
 * `task-definition-file` (required): The file containing the task definition
 
 #### Step 5 : [Downscale ECS Service](http://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_UpdateService.html)
@@ -86,6 +85,5 @@ deploy:
       secret: aws_access_secret_id
       cluster-name: staging
       service-name: hello
-      task-definition-name: hello
       task-definition-file: /app/hello-task-definition.json
 ```

--- a/ecs/__init__.py
+++ b/ecs/__init__.py
@@ -37,10 +37,9 @@ class ECSService(object):
             raise Exception("Service '%s' is %s in cluster '%s'" % (service, failures[0].get('reason'), cluster))
         return response
 
-    def register_task_definition(self, family, file):
+    def register_task_definition(self, file):
         """
         Register the task definition contained in the file
-        :param family: the task definition name
         :param file: the task definition content file
         :return: the response or raise an Exception
         """
@@ -48,9 +47,11 @@ class ECSService(object):
             raise IOError('The task definition file does not exist')
 
         with open(file, 'r') as content_file:
-            container_definitions = json.loads(content_file.read())
+            task_file = json.loads(content_file.read())
 
-        response = self.client.register_task_definition(family=family, containerDefinitions=container_definitions)
+        response = self.client.register_task_definition(family=task_file.get('family'),
+                                                        containerDefinitions=task_file.get('containerDefinitions'),
+                                                        volumes=task_file.get('volumes'))
         task_definition = response.get('taskDefinition')
         if task_definition.get('status') is 'INACTIVE':
             arn = task_definition.get('taskDefinitionArn')

--- a/main.py
+++ b/main.py
@@ -20,7 +20,6 @@ parser.add_argument('--secret', dest='secret', required=True)
 parser.add_argument('--region', dest='region', default='us-east-1')
 parser.add_argument('--cluster-name', dest='cluster_name', required=True)
 parser.add_argument('--service-name', dest='service_name', required=True)
-parser.add_argument('--task-definition-name', dest='task_definition_name', required=True)
 parser.add_argument('--task-definition-file', dest='task_definition_file', required=True)
 parser.add_argument('--minimum-running-tasks', type=int, dest='minimum_running_tasks', default=1, required=True)
 args = parser.parse_args()
@@ -44,7 +43,7 @@ try:
 
     # Step 4: Register New Task Definition
     h1("Step 4: Register New Task Definition")
-    response = ecs.register_task_definition(family=args.task_definition_name, file=args.task_definition_file)
+    response = ecs.register_task_definition(file=args.task_definition_file)
     task_definition_arn = response.get('taskDefinition').get('taskDefinitionArn')
     success("Registering task definition '%s' succeeded" % task_definition_arn)
 

--- a/run.sh
+++ b/run.sh
@@ -89,11 +89,6 @@ if [ -z "$WERCKER_AWS_ECS_SERVICE_NAME" ]; then
   exit 1
 fi
 
-if [ -z "$WERCKER_AWS_ECS_TASK_DEFINITION_NAME" ]; then
-  error "Please set the 'task-definition-name' variable"
-  exit 1
-fi
-
 if [ -z "$WERCKER_AWS_ECS_TASK_DEFINITION_FILE" ]; then
   error "Please set the 'task-definition-file' variable"
   exit 1
@@ -105,6 +100,5 @@ python "$WERCKER_STEP_ROOT/main.py" \
   --region "${WERCKER_AWS_ECS_REGION:-us-east-1}" \
   --cluster-name "$WERCKER_AWS_ECS_CLUSTER_NAME" \
   --service-name "$WERCKER_AWS_ECS_SERVICE_NAME" \
-  --task-definition-name "$WERCKER_AWS_ECS_TASK_DEFINITION_NAME" \
   --task-definition-file "$WERCKER_AWS_ECS_TASK_DEFINITION_FILE" \
   --minimum-running-tasks "${WERCKER_AWS_ECS_MINIMUM_RUNNING_TASKS:-1}"

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -23,9 +23,6 @@ properties:
   service-name:
     type: string
     required: true
-  task-definition-name:
-    type: string
-    required: true
   task-definition-file:
     type: string
     required: true


### PR DESCRIPTION
Previously the task definition file required by this step was actually just an array of container definitions -- one of three main sections of a task definition. This commit reads the task definition file as a full ECS task definition, including keys for the family name and the optional 'volumes' section which previously couldn't be defined in this step at all.  Since the family is now defined in this file, the need to specify the family as an argument in this step has been eliminated, and the argument has been removed.
